### PR TITLE
Update BaseEncoder to handle unseen values correctly in transform

### DIFF
--- a/mlencoders/base_encoder.py
+++ b/mlencoders/base_encoder.py
@@ -41,7 +41,7 @@ class BaseEncoder(object):
 
         X_encoded = X.copy(deep=True)
         for col, mapping in self._mapping.items():
-            X_encoded[col] = mapping['value'].loc[X_encoded[col].fillna(NAN_CATEGORY)].values
+            X_encoded.loc[:,col] = X_encoded[col].fillna(NAN_CATEGORY).map(mapping['value'])
 
             if self.handle_unseen == 'impute':
                 X_encoded[col].fillna(self._imputed, inplace=True)

--- a/mlencoders/base_encoder.py
+++ b/mlencoders/base_encoder.py
@@ -41,7 +41,7 @@ class BaseEncoder(object):
 
         X_encoded = X.copy(deep=True)
         for col, mapping in self._mapping.items():
-            X_encoded.loc[:,col] = X_encoded[col].fillna(NAN_CATEGORY).map(mapping['value'])
+            X_encoded.loc[:, col] = X_encoded[col].fillna(NAN_CATEGORY).map(mapping['value'])
 
             if self.handle_unseen == 'impute':
                 X_encoded[col].fillna(self._imputed, inplace=True)


### PR DESCRIPTION
In the previous implementation, unseen values during the transform
method raise a KeyError when all category values are unseen. 
Eg:
![image](https://user-images.githubusercontent.com/21316571/51005941-c5d31980-14f5-11e9-956c-95f3d692de67.png)

The new implementation correctly replaces unseen values with NaN
and allows the following if statement to execute correctly.